### PR TITLE
GET Credential Type Endpoint for Verification page data

### DIFF
--- a/server/src/controllers/issuance.controller.ts
+++ b/server/src/controllers/issuance.controller.ts
@@ -19,4 +19,17 @@ export class IssuanceController {
       next(err);
     }
   }
+
+  static async issuers(req: Request, res: Response, next: NextFunction) {
+    try {
+      const data = await IssuanceService.issuers();
+
+      res.status(200).json({
+        status: "success",
+        data,
+      });
+    } catch (err) {
+      next(err);
+    }
+  }
 }

--- a/server/src/models/issuer.model.ts
+++ b/server/src/models/issuer.model.ts
@@ -37,4 +37,20 @@ export class IssuerModel {
       },
     });
   }
+
+  static getAllWithCredentialTypes() {
+    return prisma.issuer.findMany({
+      where: {
+        contract_address: {
+          not: null,
+        },
+        credential_types: {
+          some: {},
+        },
+      },
+      include: {
+        credential_types: true,
+      },
+    });
+  }
 }

--- a/server/src/routes/issuance.route.ts
+++ b/server/src/routes/issuance.route.ts
@@ -3,5 +3,6 @@ import { IssuanceController } from "../controllers/issuance.controller";
 const router = express.Router();
 
 router.put("/address", IssuanceController.address);
+router.get("/issuers", IssuanceController.issuers);
 
 export default router;

--- a/server/src/services/issuance.service.ts
+++ b/server/src/services/issuance.service.ts
@@ -2,6 +2,7 @@ import { Address } from "viem";
 import { UserModel } from "../models/user.model";
 import { ControllerError } from "../utils/error.util";
 import { ERROR_TITLES } from "../config/constants.config";
+import { IssuerModel } from "../models/issuer.model";
 export class IssuanceService {
   static async address(email: string, address: Address) {
     const user = await UserModel.findUserByEmail(email);
@@ -19,5 +20,11 @@ export class IssuanceService {
     }
 
     await UserModel.updateUser(user.id, { address });
+  }
+
+  static async issuers() {
+    const issuers = await IssuerModel.getAllWithCredentialTypes();
+
+    return issuers;
   }
 }


### PR DESCRIPTION
Simple enough, api endpoint to retrieve all of the issuers and credential types for filtering out the forms on the FE so users can search for institutions and their credential types that they want to verify. I think for where we are currently at in our app state we don't need to worry about pagination or the amount of data we return back.