### PR TITLE
POST Verify credentials endpoint

### DIFF
--- a/server/src/chainEvents.ts
+++ b/server/src/chainEvents.ts
@@ -15,7 +15,7 @@ import { IssuerModel } from "./models/issuer.model";
 
 //NEEDSWORK EVENTUALLY: load contract addresses according to the environment
 
-const publicClient = createPublicClient({
+export const publicClient = createPublicClient({
   chain: hardhat,
   transport: http(),
 });

--- a/server/src/controllers/issuance.controller.ts
+++ b/server/src/controllers/issuance.controller.ts
@@ -19,4 +19,23 @@ export class IssuanceController {
       next(err);
     }
   }
+
+  static async verify(req: Request, res: Response, next: NextFunction) {
+    try {
+      SchemaValidationUtil.verifyCredentialsSchema.parse(req.body);
+
+      const { email, credential_types } = req.body;
+
+      const result = await IssuanceService.verify(email, credential_types);
+
+      res.status(200).json({
+        status: "success",
+        data: {
+          valid: result,
+        },
+      });
+    } catch (err) {
+      next(err);
+    }
+  }
 }

--- a/server/src/models/credentialType.model.ts
+++ b/server/src/models/credentialType.model.ts
@@ -13,6 +13,19 @@ export class CredentialTypeModel {
     });
   }
 
+  static async findByIds(ids: number[]) {
+    return prisma.credentialType.findMany({
+      where: {
+        id: {
+          in: ids,
+        },
+      },
+      include: {
+        issuer: true,
+      },
+    });
+  }
+
   static async findIssuerCredentialTypes(
     issuer_id: number
   ): Promise<CredentialType[]> {

--- a/server/src/routes/issuance.route.ts
+++ b/server/src/routes/issuance.route.ts
@@ -3,5 +3,6 @@ import { IssuanceController } from "../controllers/issuance.controller";
 const router = express.Router();
 
 router.put("/address", IssuanceController.address);
+router.post("/verify", IssuanceController.verify);
 
 export default router;

--- a/server/src/services/issuance.service.ts
+++ b/server/src/services/issuance.service.ts
@@ -2,6 +2,9 @@ import { Address } from "viem";
 import { UserModel } from "../models/user.model";
 import { ControllerError } from "../utils/error.util";
 import { ERROR_TITLES } from "../config/constants.config";
+import { CredentialTypeModel } from "../models/credentialType.model";
+import { publicClient } from "../chainEvents";
+import { institutionCredentialAbi } from "../utils/abi.util";
 export class IssuanceService {
   static async address(email: string, address: Address) {
     const user = await UserModel.findUserByEmail(email);
@@ -19,5 +22,39 @@ export class IssuanceService {
     }
 
     await UserModel.updateUser(user.id, { address });
+  }
+
+  static async verify(email: string, credentialTypeIds: number[]) {
+    const user = await UserModel.findUserByEmail(email);
+
+    if (!user || !user.address) {
+      throw new ControllerError(
+        ERROR_TITLES.DNE,
+        `No user exists for the email: ${email}`
+      );
+    }
+
+    const credentialTypes = await CredentialTypeModel.findByIds(
+      credentialTypeIds
+    );
+
+    if (credentialTypeIds.length !== credentialTypeIds.length) {
+      throw new ControllerError(ERROR_TITLES.DNE, "Not all id's are valid");
+    }
+
+    for (const credentialType of credentialTypes) {
+      const valid = await publicClient.readContract({
+        address: credentialType.issuer.contract_address as Address,
+        abi: institutionCredentialAbi,
+        functionName: "verifyCredential",
+        args: [user.address, credentialType.token_id],
+      });
+
+      if (!valid) {
+        return false;
+      }
+    }
+
+    return true;
   }
 }

--- a/server/src/utils/schema_validation.util.ts
+++ b/server/src/utils/schema_validation.util.ts
@@ -19,4 +19,13 @@ export class SchemaValidationUtil {
     email: emailSchema,
     address: z.string(),
   });
+
+  static verifyCredentialsSchema = z.object({
+    email: emailSchema,
+    credential_types: z.array(
+      z.object({
+        credential_type_id: z.number(),
+      })
+    ),
+  });
 }


### PR DESCRIPTION
Created a verify credentials endpoint so we can pass in an email and a list of credential type id's, which the BE will then validate against the chain to confirm that they do in fact exist. 

(This schema for what we pass in and how we parse the logic is definitely malleable, willing to change to a list of emails, or email per credential, etc.)