### PR TITLE
Issue cred with email

### DIFF
--- a/client/src/pages/IssueCredential.tsx
+++ b/client/src/pages/IssueCredential.tsx
@@ -92,6 +92,9 @@ export default function IssueCredential() {
     if (!emailRegex.test(formData.email)) {
       setError("Please enter a valid email address");
       return false;
+    } else if (formData.email === user?.email) {
+      setError("You cannot issue a credential to yourself");
+      return false;
     }
     return true;
   };

--- a/client/src/pages/IssueCredential.tsx
+++ b/client/src/pages/IssueCredential.tsx
@@ -118,7 +118,6 @@ export default function IssueCredential() {
         if (!userAddress) {
           return;
         }
-        console.log(userAddress);
 
         const credID = BigInt(formData.credentialId.slice(0, -1));
         onIssueInstitutionCredential(

--- a/client/src/utils/user.util.ts
+++ b/client/src/utils/user.util.ts
@@ -76,3 +76,16 @@ export async function updateUserAddress(
     return { status: false };
   }
 }
+
+export async function getUserAddress(email: string) {
+  try{
+    const token = sessionStorage.getItem("token");
+    const response = await fetch(`http:localhost:3000/issuances/user/${email}`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    });
+  }
+}

--- a/client/src/utils/user.util.ts
+++ b/client/src/utils/user.util.ts
@@ -78,17 +78,18 @@ export async function updateUserAddress(
   }
 }
 
-export async function getUserAddress(email: string) {
+export async function retrieveUserAddress(email: string) {
   try {
     const token = sessionStorage.getItem("token");
     const response = await fetch(
-      `http:localhost:3000/issuances/user/${email}`,
+      `http://localhost:3000/issuances/address/user`,
       {
-        method: "GET",
+        method: "POST",
         headers: {
           "Content-Type": "application/json",
           ...(token ? { Authorization: `Bearer ${token}` } : {}),
         },
+        body: JSON.stringify({ email }),
       }
     );
 

--- a/client/src/utils/user.util.ts
+++ b/client/src/utils/user.util.ts
@@ -53,7 +53,7 @@ export async function updateUserAddress(
       }),
       headers: {
         "Content-Type": "application/json",
-        ...(token ? { Authorization: `Bearer ${token}` } : {})
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
       },
     });
 
@@ -78,14 +78,36 @@ export async function updateUserAddress(
 }
 
 export async function getUserAddress(email: string) {
-  try{
+  try {
     const token = sessionStorage.getItem("token");
-    const response = await fetch(`http:localhost:3000/issuances/user/${email}`, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
-    });
+    const response = await fetch(
+      `http:localhost:3000/issuances/user/${email}`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+      }
+    );
+
+    const data = await response.json();
+
+    if (data.status === "success") {
+      return {
+        status: true,
+        address: data.data.address,
+      };
+    } else {
+      return {
+        status: false,
+        message: parseApiError(data),
+      };
+    }
+  } catch (error) {
+    return {
+      status: false,
+      message: "Failed to fetch user address from email: " + error,
+    };
   }
 }

--- a/server/src/controllers/issuance.controller.ts
+++ b/server/src/controllers/issuance.controller.ts
@@ -51,4 +51,23 @@ export class IssuanceController {
       next(err);
     }
   }
+
+  static async retrieve(req: Request, res: Response, next: NextFunction) {
+    try {
+      SchemaValidationUtil.retrieveAddressSchema.parse(req.body);
+
+      const { email } = req.body;
+
+      const address = await IssuanceService.retrieveAddress(email);
+
+      res.status(200).json({
+        status: "success",
+        data: {
+          address,
+        },
+      });
+    } catch (err) {
+      next(err);
+    }
+  }
 }

--- a/server/src/routes/issuance.route.ts
+++ b/server/src/routes/issuance.route.ts
@@ -4,6 +4,7 @@ import { authenticateToken } from "../middleware/auth";
 const router = express.Router();
 
 router.put("/address", authenticateToken, IssuanceController.address);
+router.post("/address/user", authenticateToken, IssuanceController.retrieve);
 router.post("/verify", IssuanceController.verify);
 router.get("/issuers", IssuanceController.issuers);
 

--- a/server/src/services/issuance.service.ts
+++ b/server/src/services/issuance.service.ts
@@ -26,6 +26,24 @@ export class IssuanceService {
     await UserModel.updateUserAddress(user.id, address);
   }
 
+  static async retrieveAddress(email: string) {
+    const user = await UserModel.findUserByEmail(email);
+
+    if (!user) {
+      throw new ControllerError(
+        ERROR_TITLES.DNE,
+        `No user exists for the email: ${email}`
+      );
+    } else if (!user.address) {
+      throw new ControllerError(
+        ERROR_TITLES.DATA,
+        `User has not connected their wallet yet`
+      );
+    }
+
+    return user.address;
+  }
+
   static async issuers() {
     const issuers = await IssuerModel.getAllWithCredentialTypes();
 

--- a/server/src/utils/schema_validation.util.ts
+++ b/server/src/utils/schema_validation.util.ts
@@ -20,6 +20,10 @@ export class SchemaValidationUtil {
     address: z.string(),
   });
 
+  static retrieveAddressSchema = z.object({
+    email: emailSchema,
+  });
+
   static verifyCredentialsSchema = z.object({
     email: emailSchema,
     credential_types: z.array(z.number()),


### PR DESCRIPTION
IssueCredential.tsx - updated the CredentialFormData type to include email instead of walletAddress, added validation to ensure the input was an email before submitting the form. Add in function to call the user util function that will retrieve the user wallet address

user.util.ts - added in a new function to call the backend and retrieve the user address for the email provided, it is authenticated so some random can't just hit our backend and be like yo sick got yo wallet address if they know your email.

issuance.controller.ts - don't know if the schema validation is all that necessary since it's just an email and frontend ensures it's an email

issuance.route.ts - add route to return the user address from post request with user email

issuance.service.ts - use existing findUserbyEmail and then make sure it does return a user that has an address and just return the address

schema_validation - add in the schema validation for a request with a body of just an email address




