### PR TITLE
Update the pinata to work correctly with JSON data from pinata.

### DIFF
--- a/client/src/components/CreateCredentialComponent.tsx
+++ b/client/src/components/CreateCredentialComponent.tsx
@@ -17,6 +17,7 @@ import { useNavigate } from "react-router";
 import { createCredentialType } from "../utils/credential.util";
 import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
 import CloseIcon from "@mui/icons-material/Close";
+import { uploadJsonToPinata } from "../utils/pinata.util";
 
 interface CredentialDetail {
   descriptor: string;
@@ -50,22 +51,26 @@ export default function CreateCredential({ onClose }: { onClose: () => void }) {
     jsonData: object // Eventually we will need this, right now it does nothing
   ) {
     if (user) {
-      console.log(jsonData); //just have this so error goes away
-      //First need to upload jsonData to pinata to get a cid to upload to the contract
-      // const cid = await uploadJsonToPinata(title, jsonData);
-
-      // //If successful, then we can create the credential type on our contract
-      // if (cid !== null) {
-
       if (!title) {
         setError("Please enter a Credential Name");
         return;
       }
+      //First need to upload jsonData to pinata to get a cid to upload to the contract
+      let cid: string | null = null;
 
-      await createCredentialType(user.email, title, "default cid for now");
+      if (Object.keys(jsonData).length > 0) {
+        cid = await uploadJsonToPinata(title, jsonData);
+      } else {
+        //No data to attach
+        cid = "";
+      }
 
-      return true;
-      // }
+      // //If successful, then we can create the credential type on our contract
+      if (cid !== null) {
+        await createCredentialType(user.email, title, cid);
+
+        return true;
+      }
     }
   }
 

--- a/client/src/components/CredentialIssueCard.tsx
+++ b/client/src/components/CredentialIssueCard.tsx
@@ -6,6 +6,7 @@ import {
   Button,
   Box,
   Modal,
+  CircularProgress,
 } from "@mui/material";
 import { CredentialIssue } from "../utils/user.util";
 import { useEffect, useState } from "react";
@@ -34,7 +35,9 @@ export function CredentialIssueCard({
           address: credentialIssue.credential_type.issuer.contract_address,
           abi: institutionCredentialAbi,
           functionName: "uri",
-          args: [BigInt(credentialIssue.credential_type.token_id)],
+          args: [
+            BigInt(credentialIssue.credential_type.token_id.replace(/n$/, "")),
+          ],
         })) as string;
 
         pinataJson = await getJsonDataFromPinata(cid);
@@ -64,7 +67,7 @@ export function CredentialIssueCard({
           method: "PATCH",
           headers: {
             "Content-Type": "application/json",
-            ...({ Authorization: `Bearer ${token}` }),
+            ...{ Authorization: `Bearer ${token}` },
           },
           body: JSON.stringify({ hidden: !hidden }),
         }
@@ -89,22 +92,56 @@ export function CredentialIssueCard({
         aria-labelledby="modal-modal-title"
         aria-describedby="modal-modal-description"
       >
-        <Box>
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            height: "100vh",
+          }}
+          onClick={() => setViewMoreDetails(false)}
+        >
           {moreDetails === null && loadingDetails ? (
-            <p>Loading Credential Extra Details...</p>
+            <CircularProgress />
           ) : (
-            <p>
-              {moreDetails !== null && Object.keys(moreDetails).length > 0 ? (
-                <p>{JSON.stringify(moreDetails)}</p>
-              ) : (
-                <p>There are no extra details from the institution</p>
-              )}
-            </p>
+            <Card
+              sx={{
+                width: "100%",
+                maxWidth: 500,
+                bgcolor: "white",
+                boxShadow: 3,
+              }}
+            >
+              <CardContent>
+                <Typography variant="h6" gutterBottom>
+                  Additional Information
+                </Typography>
+
+                {moreDetails !== null && Object.keys(moreDetails).length > 0 ? (
+                  Object.entries(moreDetails).map(([key, value]) => (
+                    <Box key={key} sx={{ display: "flex", gap: 1, py: 0.5 }}>
+                      <Typography
+                        variant="body2"
+                        fontWeight="bold"
+                        sx={{ textTransform: "capitalize" }}
+                      >
+                        {key}:
+                      </Typography>
+                      <Typography variant="body2">{String(value)}</Typography>
+                    </Box>
+                  ))
+                ) : (
+                  <Typography variant="body2" color="text.secondary">
+                    There are no extra details from the institution.
+                  </Typography>
+                )}
+              </CardContent>
+            </Card>
           )}
         </Box>
       </Modal>
       <Card sx={{ minWidth: 375, display: "flex", flexDirection: "column" }}>
-        <CardContent sx={{ flexGrow:1}}>
+        <CardContent sx={{ flexGrow: 1 }}>
           <Typography gutterBottom sx={{ color: "white" }}>
             {credentialIssue.credential_type.issuer.name}
           </Typography>
@@ -112,7 +149,7 @@ export function CredentialIssueCard({
             {credentialIssue.credential_type.name}
           </Typography>
         </CardContent>
-        <CardActions sx={{ mt: "auto"}}>
+        <CardActions sx={{ mt: "auto" }}>
           <Button
             onClick={() => setViewMoreDetails((current) => !current)}
             size="small"


### PR DESCRIPTION
Description: Added pinata storing data on IPFS with JSON data included when creating a credential. THen you can view the data when clicking view details on the holder's side.

Question: Do we want to add the ability to view the additional details on the holder's side when we display their created credentials in a table?

To Test: Create a credential type, add some data to include with it. Then look at the additional details on the holder page for someone you have issued the credential to and click on view details to see the data.